### PR TITLE
path typo(?) for /mrtrix3/install_mime_types.sh

### DIFF
--- a/KUL_Install_NeuroImagingSoftware.sh
+++ b/KUL_Install_NeuroImagingSoftware.sh
@@ -446,7 +446,7 @@ export PATH=${install_location}/mrtrix3/bin:\$PATH
 
 EOT
         # end cat command - see above
-        ${install_location}/KUL_apps/mrtrix3/install_mime_types.sh
+        ${install_location}/mrtrix3/install_mime_types.sh
     
         echo "echo -e \"\t mrtrix3\t-\t\$(mrconvert -version | head -1 | awk '{ print \$3 }') \"" >> $KUL_apps_versions
     else


### PR DESCRIPTION
the title explains. 

current behavior:
`./KUL_Install_NeuroImagingSoftware.sh: line 449: /usr/local/KUL_apps/KUL_apps/mrtrix3/install_mime_types.sh: No such file or directory`

